### PR TITLE
Bump for v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-cosekey",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-cosekey",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "description": "Parse COSE(CBOR Object Signing and Encryption) to JWK(JSON Web Key) or PEM.",
   "main": "index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Fix

- JWK x property must be base64url #11 
- Remove unnecessary parameter `keyType` in KeyParser#findCoseKeyParameterValueFromLabel

## Add

- Auto test with Travis CI #7
- Run Coverage with Coveralls #7
- Add badges(build result and coverage percentage)
